### PR TITLE
Fix pnet version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.8"
 md5 = "0.7.0"
 pcap = { version = "0.7.0", optional = true }
 pcap-parser = "0.9.2"
-pnet = "0.25.0"
+pnet = "0.28.0"
 tls-parser = "0.9.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Project didn't compile. Updating the version of `pnet_macros`, [as suggested](https://github.com/jabedude/ja3-rs/issues/6#issuecomment-975899475), fixes the problem.

Fixes #6 